### PR TITLE
Fix some type annotations in artiq.language.environment

### DIFF
--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -1,3 +1,4 @@
+import typing as t
 from collections import OrderedDict
 from inspect import isclass
 
@@ -281,9 +282,9 @@ class DatasetToggleValue(_SimpleArgProcessor):
 
     """
 
-    def __init__(self, argument: _SimpleArgProcessor = None,
-                 from_data_set: BooleanValue = None,
-                 data_set_value: any = None,
+    def __init__(self, argument: _SimpleArgProcessor | None = None,
+                 from_data_set: BooleanValue | None = None,
+                 data_set_value: t.Any = None,
                  default=NoDefault):
 
         self.argument = argument


### PR DESCRIPTION
This replaces the invalid `any` annotation and explicitly makes 2 arguments optional in `DatasetToggleValue.__init__`.